### PR TITLE
Resolved issue with Boolean.Subtract if there was no resulting mesh

### DIFF
--- a/CSG/Classes/CSG_VertexUtility.cs
+++ b/CSG/Classes/CSG_VertexUtility.cs
@@ -204,7 +204,7 @@ namespace Parabox.CSG
 
             mesh.Clear();
 
-            CSG_Vertex first = vertices[0];
+            CSG_Vertex first = vertices.Count != 0 ? vertices[0] : new CSG_Vertex();
 
             if (first.hasPosition) mesh.vertices = positions;
             if (first.hasColor) mesh.colors = colors;


### PR DESCRIPTION
Currently, if the subtract operation does not create a resulting mesh (due to one object being completely engulfed by another object) an error is thrown. This is due to it attempting to access the first element of an empty list. By checking for this, we can return an empty vertex, which allows for the subtraction of objects that return no results.