### PR TITLE
exposed front/back polygons to the subtraction function

### DIFF
--- a/CSG/CSG.cs
+++ b/CSG/CSG.cs
@@ -51,8 +51,10 @@ namespace Parabox.CSG
         /// </summary>
         /// <param name="lhs">The base mesh of the boolean operation.</param>
         /// <param name="rhs">The input mesh of the boolean operation.</param>
+        /// <param name="back">Draw the back polygons from the result.</param>
+        /// <param name="front">Draw the front polygons of the result.</param>
         /// <returns>A new mesh if the operation succeeds, or null if an error occurs.</returns>
-        public static CSG_Model Subtract(GameObject lhs, GameObject rhs)
+        public static CSG_Model Subtract(GameObject lhs, GameObject rhs, bool back = true, bool front = true)
         {
             CSG_Model csg_model_a = new CSG_Model(lhs);
             CSG_Model csg_model_b = new CSG_Model(rhs);
@@ -60,7 +62,7 @@ namespace Parabox.CSG
             CSG_Node a = new CSG_Node(csg_model_a.ToPolygons());
             CSG_Node b = new CSG_Node(csg_model_b.ToPolygons());
 
-            List<CSG_Polygon> polygons = CSG_Node.Subtract(a, b).AllPolygons();
+            List<CSG_Polygon> polygons = CSG_Node.Subtract(a, b).AllPolygons(back, front);
 
             return new CSG_Model(polygons);
         }

--- a/CSG/CSG.cs.meta
+++ b/CSG/CSG.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 136c7ff4a0ec419280b8df0d260180d0
+guid: ebfb4c2cfc5327c42a8bf12d68aa7bdc
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []

--- a/CSG/Classes.meta
+++ b/CSG/Classes.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 291cedf2747a43b19e37963cf9100589
+guid: 26a69eae25551d3459c97657aaabde95
 folderAsset: yes
 DefaultImporter:
   userData: 

--- a/CSG/Classes/CSG_Node.cs
+++ b/CSG/Classes/CSG_Node.cs
@@ -165,17 +165,17 @@ namespace Parabox.CSG
         }
 
         // Return a list of all polygons in this BSP tree.
-        public List<CSG_Polygon> AllPolygons()
+        public List<CSG_Polygon> AllPolygons(bool back = true, bool front = true)
         {
             List<CSG_Polygon> list = this.polygons;
             List<CSG_Polygon> list_front = new List<CSG_Polygon>(), list_back = new List<CSG_Polygon>();
 
-            if (this.front != null)
+            if (this.front != null && front)
             {
                 list_front = this.front.AllPolygons();
             }
 
-            if (this.back != null)
+            if (this.back != null && back)
             {
                 list_back = this.back.AllPolygons();
             }

--- a/CSG/Parabox.CSG.asmdef.meta
+++ b/CSG/Parabox.CSG.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 26434c0544da24d83a23c99deaa60965
+guid: c4ac77ca6e671b54d89aa1ad9c87ba9f
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Example use:
 	// Initialize two new meshes in the scene
 	GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
 	GameObject sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-	sphere.transform.localScale = Vector3.one * 1.3;
+	sphere.transform.localScale = Vector3.one * 1.3f;
 
 	// Perform boolean operation
 	CSG_Model result = Boolean.Subtract(cube, sphere);
 
 	// Create a gameObject to render the result
-	composite = new GameObject();
+	var composite = new GameObject();
 	composite.AddComponent<MeshFilter>().sharedMesh = result.mesh;
 	composite.AddComponent<MeshRenderer>().sharedMaterials = result.materials.ToArray();
 


### PR DESCRIPTION
useful control when subtracting a rhs cube from a lhs plane. This way we can do this and the plane remains a plane, without the back faces of the cube added to it.