### PR TITLE
Fix NRE

### DIFF
--- a/CSG/Classes/CSG_Node.cs
+++ b/CSG/Classes/CSG_Node.cs
@@ -167,6 +167,9 @@ namespace Parabox.CSG
         // Return a list of all polygons in this BSP tree.
         public List<CSG_Polygon> AllPolygons()
         {
+            if (this.polygons == null)
+                this.polygons = new List<CSG_Polygon>();
+
             List<CSG_Polygon> list = this.polygons;
             List<CSG_Polygon> list_front = new List<CSG_Polygon>(), list_back = new List<CSG_Polygon>();
 


### PR DESCRIPTION
I encountered a case where `polygons` may be null in `CSG_Node.AllPolygons()`.