### PR TITLE
Fix Autoreference false -> true and create CHANGELOG.md.meta

### DIFF
--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,8 @@
+@@ -0,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9e9d365796383ee4ea0baac0dff4fb5c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CSG/Parabox.CSG.asmdef
+++ b/CSG/Parabox.CSG.asmdef
@@ -7,6 +7,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": []
 }


### PR DESCRIPTION
Set autoreference to true, to avoid unknow definitions error.
As proposed by @GDGRhinox create CHANGELOG.md.meta
